### PR TITLE
Use custom "Open all" text on accordions

### DIFF
--- a/assets/javascript/global.js
+++ b/assets/javascript/global.js
@@ -1,10 +1,11 @@
 import common from "govuk-frontend/govuk/common";
-import Accordion from "govuk-frontend/govuk/components/accordion/accordion";
 import Button from "govuk-frontend/govuk/components/button/button";
 import ErrorSummary from "govuk-frontend/govuk/components/error-summary/error-summary";
 import Radios from "govuk-frontend/govuk/components/radios/radios";
 
-import initSelectAll from "./modules/select-all.js";
+import Accordion from "./modules/accordion";
+
+import initSelectAll from "./modules/select-all";
 import CookiePolicy from "./modules/cookie-banner";
 
 var cookiePolicy = new CookiePolicy();

--- a/assets/javascript/modules/accordion.js
+++ b/assets/javascript/modules/accordion.js
@@ -1,0 +1,20 @@
+import GDSAccordion from "govuk-frontend/govuk/components/accordion/accordion";
+
+class Accordion extends GDSAccordion {
+  constructor($module) {
+    super($module);
+    this.openAllSectionDescription = $module.dataset.openAllSectionDescription;
+  }
+
+  updateOpenAllButton(expanded) {
+    var newButtonText = expanded ? "Close all" : "Open all";
+    var sectionsText = this.openAllSectionDescription
+      ? ` on ${this.openAllSectionDescription}`
+      : "";
+    newButtonText += `<span class="govuk-visually-hidden"> sections${sectionsText}</span>`;
+    this.$openAllButton.setAttribute("aria-expanded", expanded);
+    this.$openAllButton.innerHTML = newButtonText;
+  }
+}
+
+export default Accordion;

--- a/export_support/core/templates/core/enquiry_contact_success.html
+++ b/export_support/core/templates/core/enquiry_contact_success.html
@@ -42,7 +42,7 @@
                             <a class="information-link-panel__link" href="{{ GOV_UK_EXPORT_GOODS_URL }}" target="_blank">Export goods from the UK: step by step</a>
                             <p class="information-link-panel__body">How to move goods from the UK to international destinations, including Europe.</p>
                         </div>
-                        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-export-goods">
+                        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-export-goods" data-open-all-section-description="exporting goods to Europe">
                             <div class="govuk-accordion__section ">
                                 <div class="govuk-accordion__section-header">
                                     <h2 class="govuk-accordion__section-heading">
@@ -266,7 +266,7 @@
                         <p class="govuk-body">Find information about selling services to Europe. All links open in a new tab.</p>
                     </div>
                     <div class="govuk-grid-column-full">
-                        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-export-services">
+                        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-export-services" data-open-all-section-description="exporting services to Europe">
                             <div class="govuk-accordion__section ">
                                 <div class="govuk-accordion__section-header">
                                     <h2 class="govuk-accordion__section-heading">

--- a/export_support/core/templates/core/non_eu_export_enquiries.html
+++ b/export_support/core/templates/core/non_eu_export_enquiries.html
@@ -28,7 +28,7 @@
                             <a class="information-link-panel__link" href="{{ GOV_UK_EXPORT_GOODS_URL }}" target="_blank">Export goods from the UK: step by step</a>
                             <p class="information-link-panel__body">How to move goods from the UK to international destinations.</p>
                         </div>
-                        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-export-goods">
+                        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-export-goods" data-open-all-section-description="exporting goods abroad">
                             <div class="govuk-accordion__section ">
                                 <div class="govuk-accordion__section-header">
                                     <h2 class="govuk-accordion__section-heading">
@@ -221,7 +221,7 @@
                         </p>
                     </div>
                     <div class="govuk-grid-column-full">
-                        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-export-services">
+                        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-export-services" data-open-all-section-description="exporting services abroad">
                             <div class="govuk-accordion__section ">
                                 <div class="govuk-accordion__section-header">
                                     <h2 class="govuk-accordion__section-heading">


### PR DESCRIPTION
This overrides the default accordion component from GDS to facilitate a custom message on the "Open/Close all" button

This is to provide better accessibility in the case there are multiple accordions on the page